### PR TITLE
create_pr_update: Use intermediary env variable to avoid unexpected side effects

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,11 +97,13 @@ runs:
 
     - name: Check workspace
       id: create_pr_update
+      env:
+        CREATE_PR: ${{ inputs.create_pr }}
       shell: bash
       run: |
         git diff --stat
         echo "create_pr_update=false" >> $GITHUB_OUTPUT
-        if [[ $(git diff --stat) != '' ]] && [[ ${{ inputs.create-pr }} == 'true' ]]; then
+        if [[ $(git diff --stat) != '' ]] && [[ "${CREATE_PR}" == 'true' ]]; then
           echo "create_pr_update=true" >> $GITHUB_OUTPUT
         fi
 


### PR DESCRIPTION
I was auditing for any "run" stanzas that accepted external inputs and found an unlikely-to-be-exploited case in 'create_pr_update'. This variable is not generally controlled by anyone except for repo owners, but I figured I should send a PR in any way.

Context: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable