### PR TITLE
Adding Customization for PR Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ jobs:
         labels-for-pr: automated pr, kind/cleanup, release-note-none # optional
         branch-for-pr: update-digests # optional
         title-for-pr: Update images digests # optional
+        description-for-pr: Update images digests # optional
         commit-message: Update images digests # optional
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,14 @@ inputs:
   title-for-pr:
     description: 'The title of the pull request.'
     default: 'Update images digests'
+  description-for-pr:
+    description: 'The description of the pull request.'
+    default: |
+      Update images digests
+
+      ```release-note
+      NONE
+      ```
   commit-message:
     description: 'The message to use when committing changes.'
     default: 'Update images digests'
@@ -119,12 +127,7 @@ runs:
         token: ${{ inputs.token }}
         commit-message: ${{ inputs.commit-message }}
         title: ${{ inputs.title-for-pr }}
-        body: |
-          Update images digests
-
-          ```release-note
-          NONE
-          ```
+        body: ${{ inputs.description-for-pr }}
         labels: ${{ inputs.labels-for-pr }}
         branch: ${{ inputs.branch-for-pr }}
         signoff: ${{ inputs.signoff }}


### PR DESCRIPTION
# Description

Implemented a new field that allows the customization of the PR message.

# Changes

   - Added the new field `description-for-pr`
   - Updated README.md to align with the new functionality
   
### Image showing the output without personalized message (remain unchanged):

![Screenshot from 2023-12-17 12-43-45](https://github.com/chainguard-dev/digestabot/assets/53947674/cb111076-bb20-486f-bc41-e121ae8eb891)

### Image displaying the output with the personalized message:

![Screenshot from 2023-12-17 12-41-46](https://github.com/chainguard-dev/digestabot/assets/53947674/f63f0ddc-a82e-4b53-b2f8-2ae6ddb6e950)

