### PR TITLE
pin chainguard-dev/actions/setup-gitsign to a sha

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         fi
 
     # Configure signed commits
-    - uses: chainguard-dev/actions/setup-gitsign@main
+    - uses: chainguard-dev/actions/setup-gitsign@57cb0b7560d9b9b081c15ac5ef689f73f4dda03e # main branch as of 2024-08-02
       if: ${{ steps.create_pr_update.outputs.create_pr_update == 'true' }}
 
     - name: Create Pull Request


### PR DESCRIPTION
... instead of floating to main branch version

- This allows us to ensure that the action dependency is immutable like the other two dependency in this same action
- This enables consumer of this action to properly add sha-pinned dependencies to their organization allowlist of actions