### PR TITLE
feat(action): support multiple items per file and output diff in PR body

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,45 +69,44 @@ runs:
             echo "Skipping testdata ${file}"
             continue
           fi
-          images=$(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" | cut -d @ -f1 | rev | cut -d = -f1 | cut -d ' ' -f1 | cut -d '"' -f1 | rev | sed -e "s/^docker:\/\///" | tr '\n' ',' || true)
-          digests=$(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" | cut -d @ -f2 | cut -d ' ' -f1 | cut -d '"' -f1 | tr '\n' ',' || true)
-          IFS=',' read -r -a images2 <<< "$images"
-          IFS=',' read -r -a digests2 <<< "$digests"
-
-          if [ -n "$images" ]; then
-              for i in "${!images2[@]}"; do
-                if [[ ${images2[i]} != *":"* ]]; then
-                  echo "Image ${images2[i]} in file $file does not have a tag, ignoring..."
-                  continue
-                fi
-                if [[ ${images2[i]} == *\.local:* ]]; then
-                  echo "Skipping local registry image ${images2[i]}"
-                  continue
-                fi
-                images2[i]=${images2[i]#\'}
-                echo "Processing ${images2[i]} in file $file"
-
-                updated_digest=
-                crane digest "${images2[i]}" > digest.log 2> logerror.txt
-                if [ $? -eq 0 ]; then
-                    updated_digest=$(cat digest.log)
-                else
-                    ERRMSG="Failed to retrieve digest info for ${images2[i]}"
-                    echo "${ERRMSG}"
-                    echo "${ERRMSG}" >> "$GITHUB_STEP_SUMMARY"
-                    cat logerror.txt >> "$GITHUB_STEP_SUMMARY"
-                fi
-                rm -f logerror.txt
-                rm -f digest.log
-
-                digests2[i]=${digests2[i]#\'}
-                if [ "$updated_digest" != "${digests2[i]}" ] && [ -n "$updated_digest" ]; then
-                  echo "Digest ${digests2[i]} for image ${images2[i]} is different, new digest is $updated_digest, updating..."
-                  sed -i -e "s/${digests2[i]}/$updated_digest/g" "$file"
-                fi
-              done
-          fi
-        done < <(find "${{ inputs.working-dir }}" -type f \( -name "*.yaml" -o -name "*.yml" -o -name "Dockerfile*" -o -name "Makefile*" -o -name "*.sh" -o -name "*.tf" -o -name "*.tfvars" \) -print0)
+          
+          # Extract all image references and their digests
+          mapfile -t image_lines < <(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" || true)
+          
+          for line in "${image_lines[@]}"; do
+            image=$(echo "$line" | cut -d @ -f1 | rev | cut -d = -f1 | cut -d ' ' -f1 | cut -d '"' -f1 | rev | sed -e "s/^docker:\/\///")
+            digest=$(echo "$line" | cut -d @ -f2 | cut -d ' ' -f1 | cut -d '"' -f1)
+            
+            if [[ "$image" != *":"* ]]; then
+              echo "Image $image in file $file does not have a tag, ignoring..."
+              continue
+            fi
+            if [[ "$image" == *\.local:* ]]; then
+              echo "Skipping local registry image $image"
+              continue
+            fi
+            
+            echo "Processing $image in file $file"
+            
+            updated_digest=
+            crane digest "$image" > digest.log 2> logerror.txt
+            if [ $? -eq 0 ]; then
+                updated_digest=$(cat digest.log)
+            else
+                ERRMSG="Failed to retrieve digest info for $image"
+                echo "$ERRMSG"
+                echo "$ERRMSG" >> "$GITHUB_STEP_SUMMARY"
+                cat logerror.txt >> "$GITHUB_STEP_SUMMARY"
+            fi
+            rm -f logerror.txt
+            rm -f digest.log
+            
+            if [ "$updated_digest" != "$digest" ] && [ -n "$updated_digest" ]; then
+              echo "Digest $digest for image $image is different, new digest is $updated_digest, updating..."
+              sed -i -e "s|$image@$digest|$image@$updated_digest|g" "$file"
+            fi
+          done
+        done < <(find "${{ inputs.working-dir }}" -type f \( -name "*.yaml" -o -name "*.yml" -o -name "Dockerfile*" -o -name "Makefile*" -o -name "*.sh" \) -print0)
 
     - name: Check workspace
       id: create_pr_update
@@ -119,6 +118,9 @@ runs:
         echo "create_pr_update=false" >> $GITHUB_OUTPUT
         if [[ $(git diff --stat) != '' ]] && [[ "${CREATE_PR}" == 'true' ]]; then
           echo "create_pr_update=true" >> $GITHUB_OUTPUT
+          echo "diff<<EOF" >> "${GITHUB_OUTPUT}"
+          git diff >> "${GITHUB_OUTPUT}"
+          echo "EOF" >> "${GITHUB_OUTPUT}"
         fi
 
     # Configure signed commits
@@ -133,7 +135,13 @@ runs:
         token: ${{ inputs.token }}
         commit-message: ${{ inputs.commit-message }}
         title: ${{ inputs.title-for-pr }}
-        body: ${{ inputs.description-for-pr }}
+        body: |
+          ${{ inputs.description-for-pr }}
+
+          ## Changes
+          ```diff
+          ${{ steps.create_pr_update.outputs.diff }}
+          ```
         labels: ${{ inputs.labels-for-pr }}
         branch: ${{ inputs.branch-for-pr }}
         signoff: ${{ inputs.signoff }}


### PR DESCRIPTION
### The purpose of this PR is to introduce two new features:

1. Enhance the processing logic to handle multiple digests in a single file. Current implementation seems to only work for a single digest in a given file. It is useful for this to handle multiple digests per file (e.g. a multistage Dockerfile referencing more than one base images with their own unique digests)
2. Provide a diff of the changes in the body of the pull request that gets created, appended after the `description-for-pr` input string. The screenshot below illustrates how this change looks in a pull request

<img width="1246" alt="image" src="https://github.com/user-attachments/assets/a25652a2-0610-4538-9a42-a1031b4d8442">

We've been running a local copy of this action with these changes and would like to add this to the real upstream action if desired.

### Considerations

- If you prefer to have these two features handled as separate PRs, just let me know
- If there is a more desirable way to handle the diff output in the PR (i.e. maybe it should be optional?), just let me know!