### PR TITLE
working-dir: update git stat to use input.working-dir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -117,6 +117,7 @@ runs:
         CREATE_PR: ${{ inputs.create-pr }}
       shell: bash
       run: |
+        cd "${{ inputs.working-dir }}"
         git diff --stat
         echo "create_pr_update=false" >> $GITHUB_OUTPUT
         if [[ $(git diff --stat) != '' ]] && [[ "${CREATE_PR}" == 'true' ]]; then


### PR DESCRIPTION
Patches https://github.com/chainguard-dev/digestabot/issues/49

It's safe to cd into the directory without checking whether the input is set because the default value of `inputs.working-dir` is `.`.

Author: Alexi Kessler <alexi@synqly.com>