### PR TITLE
feat: add registry-map input for proxy/mirror support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -181,3 +181,55 @@ jobs:
               echo "Other files have been modified or there are no changes"
               exit 1
           fi
+
+  test-registry-map:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Digestabot with registry-map
+        uses: ./
+        id: digestabot
+        with:
+          create-pr: false
+          working-dir: './testfiles/registry-map'
+          include-files: 'fixture.image'
+          registry-map: 'us-docker.pkg.dev/fake-proxy/=cgr.dev/'
+
+      - name: Verify proxy URL preserved and digest updated
+        shell: bash
+        run: |
+          file='testfiles/registry-map/fixture.image'
+
+          # The proxy URL prefix must still be in the file (not rewritten to cgr.dev)
+          if ! grep -q 'us-docker.pkg.dev/fake-proxy/chainguard/static:latest' "$file"; then
+            echo "Error: proxy URL prefix was not preserved in $file"
+            cat "$file"
+            exit 1
+          fi
+
+          # The placeholder digest (all zeros) must have been replaced
+          if grep -q '@sha256:0000000000000000000000000000000000000000000000000000000000000000' "$file"; then
+            echo "Error: placeholder digest was not updated in $file"
+            cat "$file"
+            exit 1
+          fi
+
+          # The updated digest must be a valid sha256
+          if ! grep -qE '@sha256:[a-f0-9]{64}' "$file"; then
+            echo "Error: no valid sha256 digest found in $file"
+            cat "$file"
+            exit 1
+          fi
+
+          echo "Registry-map test passed:"
+          cat "$file"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ jobs:
         commit-message: Update images digests # optional
 ```
 
+### Registry Mapping
+
+When pulling images through a registry proxy (e.g. GCP Artifact Registry), the proxy may return stale digests. Use `registry-map` to resolve digests against the upstream registry while keeping the proxy URL in your files:
+
+```yaml
+    - uses: chainguard-dev/digestabot@43222237fd8a07dc41a06ca13e931c95ce2cedac # v1.2.2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        registry-map: 'us-docker.pkg.dev/my-project/cgr/=cgr.dev/,us-docker.pkg.dev/my-project/ghcr/=ghcr.io/'
+```
+
 The `json` output describes the updates that `digestabot` has made and makes it
 possible to extend the functionality of the action and act on the updates in
 subsequent steps.
@@ -179,6 +190,7 @@ patchesJSON6902:
 | `commit-message` | The message to use when committing changes.  | `Update images digests` |
 | `create-pr` | Create a PR or just keep the changes locally.  | `true` |
 | `use-gitsign` | Use gitsign to sign commits.  | `true` |
+| `registry-map` | Comma-separated registry prefix mappings (proxy=upstream) for digest lookups. e.g. us-docker.pkg.dev/my-proj/cgr/=cgr.dev/  | `` |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
   use-gitsign:
     description: 'Use gitsign to sign commits.'
     default: 'true'
+  registry-map:
+    description: 'Comma-separated registry prefix mappings (proxy=upstream) for digest lookups. e.g. us-docker.pkg.dev/my-proj/cgr/=cgr.dev/'
+    required: false
+    default: ""
 
 outputs:
   pull_request_number:
@@ -99,6 +103,11 @@ runs:
 
         IFS=',' read -ra PATTERNS <<< "${{ inputs.include-files }}"
 
+        REGISTRY_MAPPINGS=()
+        if [ -n "${{ inputs.registry-map }}" ] ; then
+          IFS=',' read -ra REGISTRY_MAPPINGS <<< "${{ inputs.registry-map }}"
+        fi
+
         json='{}'
         changed_files=()
         while IFS= read -r -d '' file; do
@@ -125,12 +134,24 @@ runs:
 
             echo "Processing $image in file $file"
 
+            lookup_image="$image"
+            for mapping in "${REGISTRY_MAPPINGS[@]}"; do
+              proxy="${mapping%%=*}"
+              upstream="${mapping#*=}"
+              if [[ "$lookup_image" == "${proxy}"* ]]; then
+                lookup_image="${upstream}${lookup_image#${proxy}}"
+                echo "  Registry mapping: querying $lookup_image instead of $image"
+                break
+              fi
+            done
+
             updated_digest=
-            crane digest "$image" > digest.log 2> logerror.txt
+            crane digest "$lookup_image" > digest.log 2> logerror.txt
             if [ $? -eq 0 ]; then
                 updated_digest=$(cat digest.log)
             else
                 ERRMSG="Failed to retrieve digest info for $image"
+                [ "$lookup_image" != "$image" ] && ERRMSG="$ERRMSG (upstream: $lookup_image)"
                 echo "$ERRMSG"
                 echo "$ERRMSG" >> "$GITHUB_STEP_SUMMARY"
                 cat logerror.txt >> "$GITHUB_STEP_SUMMARY"

--- a/testfiles/registry-map/fixture.image
+++ b/testfiles/registry-map/fixture.image
@@ -1,0 +1,4 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM us-docker.pkg.dev/fake-proxy/chainguard/static:latest@sha256:0000000000000000000000000000000000000000000000000000000000000000


### PR DESCRIPTION
## Problem

When pulling images through a registry proxy or pull-through cache (e.g. GCP Artifact Registry remote repository, JFrog Artifactory, or AWS ECR pull-through cache), the proxy may cache the tag-to-digest mapping and serve stale digests indefinitely. Digestabot resolves digests from whatever registry URL is in the file, so it queries the proxy, sees the same cached digest, and never opens a PR, even when the upstream registry has a newer image.

## Solution

Add a `registry-map` input that accepts comma-separated `proxy=upstream` prefix mappings. Before calling `crane digest`, the image URL is translated to the upstream registry for the lookup. The `sed` replacement still uses the original URL from the file, so proxy references are preserved.

### Usage

```yaml
- uses: chainguard-dev/digestabot@main
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    registry-map: 'us-docker.pkg.dev/my-project/cgr/=cgr.dev/'
```

With this config, an image reference like:
```
us-docker.pkg.dev/my-project/cgr/chainguard/python:3.13-dev@sha256:abc...
```

Will have its digest resolved against `cgr.dev/chainguard/python:3.13-dev`, but the file keeps the `us-docker.pkg.dev` URL unchanged.

Multiple mappings are supported:
```yaml
registry-map: 'us-docker.pkg.dev/my-project/cgr/=cgr.dev/,us-docker.pkg.dev/my-project/ghcr/=ghcr.io/'
```

## Changes

- `action.yml`: new `registry-map` input, prefix-matching translation before `crane digest`
- `README.md`: documentation and input table entry

This defaults to no mappings to preserve backwards compatibility.