### PR TITLE
Replace setup-crane with direct installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,50 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
+    - name: Install crane
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Pin crane version and checksums
+        CRANE_VERSION="v0.21.3"
+
+        # Detect architecture
+        arch=$(uname -m)
+        if [[ "$arch" =~ (aarch64|arm64) ]]; then
+          arch="arm64"
+          EXPECTED_CHECKSUM="dabcf2aee76ca72da63b5da5137c910a6852ccff13e35628e8f0a9dd8b73f4f3"
+        else
+          arch="x86_64"
+          EXPECTED_CHECKSUM="46dbf12d943efa5673ab654186c5d7c1503580544de0df9325537083436fe5d0"
+        fi
+
+        echo "Installing crane ${CRANE_VERSION} for Linux ${arch}"
+
+        # Download crane from official GitHub releases
+        crane_tar="go-containerregistry_Linux_${arch}.tar.gz"
+        crane_url="https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/${crane_tar}"
+
+        curl -fsSL --retry 5 --retry-delay 1 --retry-all-errors -o "${crane_tar}" "${crane_url}"
+
+        # Verify SHA256 checksum
+        echo "${EXPECTED_CHECKSUM}  ${crane_tar}" | sha256sum --check --strict -
+
+        # Extract directly to destination and add to PATH
+        mkdir -p "${HOME}/.local/bin"
+        tar -xzf "${crane_tar}" -C "${HOME}/.local/bin" crane
+        echo "${HOME}/.local/bin" >> $GITHUB_PATH
+
+        # Verify installation
+        crane version
+
+        # Clean up
+        rm -f "${crane_tar}"
+
+    - name: Authenticate crane
+      shell: bash
+      run: |
+        echo "${{ inputs.token }}" | crane auth login ghcr.io --username "${{ github.actor }}" --password-stdin
 
     - shell: bash
       id: update_files


### PR DESCRIPTION
In our own org especially after the Trivy supply chain attacks, we've been wanting to be more restrictive with what 3rd-party GitHub actions can run on our workflows. (related issue: #58) 

Checksums for crane install obtained from https://github.com/google/go-containerregistry/releases/tag/v0.21.3

---
Disclaimer: Generated by Claude Code

Remove dependency on imjasonh/setup-crane by directly downloading and installing crane from official google/go-containerregistry releases.

Changes:
- Download crane v0.21.3 from official GitHub releases
- Verify SHA256 checksums for security (x86_64 and arm64)
- Extract directly to ~/.local/bin and add to PATH
- Authenticate with ghcr.io using inputs.token
- Includes retry logic for network resilience

No external action dependency required, improving compatibility with restricted GitHub Enterprise environments.