### PR TITLE
fix: route registry-map through env var (zizmor template injection)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -143,6 +143,7 @@ runs:
       env:
         INPUTS_INCLUDE_FILES: ${{ inputs.include-files }}
         INPUTS_WORKING_DIR: ${{ inputs.working-dir }}
+        INPUTS_REGISTRY_MAP: ${{ inputs.registry-map }}
       run: |
         # disable the errexit github enable that by default
         set +o errexit
@@ -150,8 +151,8 @@ runs:
         IFS=',' read -ra PATTERNS <<< "${INPUTS_INCLUDE_FILES}"
 
         REGISTRY_MAPPINGS=()
-        if [ -n "${{ inputs.registry-map }}" ] ; then
-          IFS=',' read -ra REGISTRY_MAPPINGS <<< "${{ inputs.registry-map }}"
+        if [ -n "${INPUTS_REGISTRY_MAP}" ] ; then
+          IFS=',' read -ra REGISTRY_MAPPINGS <<< "${INPUTS_REGISTRY_MAP}"
         fi
 
         json='{}'


### PR DESCRIPTION
Follow-up to #72.

zizmor flagged the inline `${{ inputs.registry-map }}` interpolation in `run:` as a code injection sink. The existing inputs (`include-files`, `working-dir`) already use the safe pattern (assign in `env:` block, reference as a shell variable). This brings `registry-map` in line.

```diff
       env:
         INPUTS_INCLUDE_FILES: ${{ inputs.include-files }}
         INPUTS_WORKING_DIR: ${{ inputs.working-dir }}
+        INPUTS_REGISTRY_MAP: ${{ inputs.registry-map }}
       run: |
         IFS=',' read -ra PATTERNS <<< "${INPUTS_INCLUDE_FILES}"

         REGISTRY_MAPPINGS=()
-        if [ -n "${{ inputs.registry-map }}" ] ; then
-          IFS=',' read -ra REGISTRY_MAPPINGS <<< "${{ inputs.registry-map }}"
+        if [ -n "${INPUTS_REGISTRY_MAP}" ] ; then
+          IFS=',' read -ra REGISTRY_MAPPINGS <<< "${INPUTS_REGISTRY_MAP}"
         fi
```

Should clear the three zizmor findings on `action.yml` from #72.

cc @cpanato