### PR TITLE
fix(ci): resolve template injection and add zizmor pedantic config

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,13 +9,17 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
-      - '.action.yml'
+      - 'action.yml'
+      - '.github/zizmor.yml'
+      - '.github/dependabot.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
-      - '.action.yml'
+      - 'action.yml'
+      - '.github/zizmor.yml'
+      - '.github/dependabot.yml'
 
 permissions: {}
 
@@ -44,3 +48,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true

--- a/action.yml
+++ b/action.yml
@@ -135,8 +135,11 @@ runs:
 
     - name: Authenticate crane
       shell: bash
+      env:
+        INPUTS_TOKEN: ${{ inputs.token }}
+        GITHUB_ACTOR: ${{ github.actor }}
       run: |
-        echo "${{ inputs.token }}" | crane auth login ghcr.io --username "${{ github.actor }}" --password-stdin
+        echo "$INPUTS_TOKEN" | crane auth login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
 
     - shell: bash
       id: update_files
@@ -271,9 +274,11 @@ runs:
     - name: Configure git credentials
       if: ${{ steps.create_pr_update.outputs.create_pr_update == 'true' }}
       shell: bash
+      env:
+        INPUTS_TOKEN: ${{ inputs.token }}
       run: |
         git config --global credential.helper store
-        echo "https://x-access-token:${{ inputs.token }}@github.com" > ~/.git-credentials
+        echo "https://x-access-token:${INPUTS_TOKEN}@github.com" > ~/.git-credentials
 
     - name: Create Pull Request
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/action.yml
+++ b/action.yml
@@ -218,6 +218,8 @@ runs:
               echo "Digest $digest for image $image is different, new digest is $updated_digest, updating..."
               sed -i -e "s|$image@$digest|$image@$updated_digest|g" "$file"
               # Add file to changed_files array if not already present
+              # shellcheck disable=SC2076 -- quoted RHS is intentional: literal match guards
+              #   against regex metacharacters in filenames; see docs/backlog.md for refactor note
               if [[ ! " ${changed_files[*]} " =~ " ${file} " ]]; then
                 changed_files+=("$file")
               fi


### PR DESCRIPTION

## Summary

Three-patch series hardening the digestabot GitHub Actions composite action and CI
workflows as part of the PSEC-923 GitHub Actions security remediation campaign.

## Patch 1: fix(ci): resolve template injection findings

**File changed**: `action.yml`

Moves three `${{ context }}` template expressions from `run:` blocks into `env:`
variables, eliminating shell injection vectors in two steps of the composite
action. (The third originally-flagged step — the unnamed "update_files" step /
`INPUTS_REGISTRY_MAP` — was already fixed upstream in commit `5d498c7`.)

1. **"Authenticate crane" step** — `${{ inputs.token }}` and `${{ github.actor }}`
   moved to `env: INPUTS_TOKEN` and `env: GITHUB_ACTOR`. The `run:` block now
   references `$INPUTS_TOKEN` and `$GITHUB_ACTOR` instead of expanding template
   expressions directly inside the shell command. An `env:` block is added before
   `run:` (no prior `env:` existed on this step).

2. **"Configure git credentials" step** — `${{ inputs.token }}` used to construct
   a `~/.git-credentials` URL is moved to `env: INPUTS_TOKEN`. The `run:` block
   now writes `${INPUTS_TOKEN}` into the credentials file. An `env:` block is
   added before `run:` (no prior `env:` existed on this step).

All `${{ }}` expressions remaining in the file after this patch appear in `env:`
blocks, `if:` conditions, `with:` fields, `value:` fields, or `default:` fields —
none of which are interpreted by the shell.

**Finding type**: `template-injection` (zizmor, Severity: High, Confidence: High,
Persona: Regular). 3 flagged expansions across 2 steps, all in `action.yml`.

## Patch 2: fix(ci): add pedantic persona and suppress noisy zizmor rules

**Files changed**: `.github/workflows/zizmor.yaml`, `.github/zizmor.yml` (new)

Two changes:

**a) `.github/zizmor.yml` created** with suppressions for two pedantic-only rules
that have no security value and would produce excessive CI noise:
- `anonymous-definition`: disabled (cosmetic, no security impact)
- `concurrency-limits`: disabled (low security value, extremely noisy across the
  codebase; 4 findings in this repo alone)

**b) `.github/workflows/zizmor.yaml` updated**:
- `persona: pedantic` added to the `zizmorcore/zizmor-action` step so that CI
  runs zizmor in pedantic mode, catching all template expansions in `run:` blocks
  rather than only attacker-controlled ones (regular mode).
- `paths:` trigger lists corrected and extended:
  - `.action.yml` (incorrect — no leading dot) replaced with `action.yml`
  - `.github/zizmor.yml` added (so changes to the suppressions file trigger CI)
  - `.github/dependabot.yml` added (so changes to dependabot config trigger CI)

## Patch 3: fix(ci): suppress SC2076 on intentional literal array membership test

**File changed**: `action.yml`

Adds an inline `# shellcheck disable=SC2076` comment immediately before the
`[[ ! " ${changed_files[*]} " =~ " ${file} " ]]` conditional in the file-tracking
loop. The quoted RHS is intentional: filenames may contain regex metacharacters
(e.g. dots) that would cause false positive membership matches if left unquoted.
The suppression comment documents the rationale so reviewers understand the
deviation from shellcheck's default guidance.

**Finding type**: shellcheck SC2076 (quoted right-hand side of `=~`). No logic
change; suppression only.

## What was not auto-fixed

**github-env finding** (1 finding, `action.yml` step[0] "Install crane"):
`echo "${HOME}/.local/bin" >> $GITHUB_PATH` is flagged by zizmor as a write to
`GITHUB_PATH`. Analysis shows this is a low-risk finding: the path is derived
from `$HOME` (runner-controlled), no action input flows into the written value,
and the binary placed in that directory is SHA256-verified before installation.
See `manual-review.md` for the full analysis and suppression options.

## Testing

- Apply patches to a branch and open a PR against `main`.
- The updated zizmor workflow (with `persona: pedantic` and the new
  `.github/zizmor.yml` suppressions) will self-validate on the PR.
- Confirm the "Run zizmor" step passes with zero findings.
- The existing test workflows (`test.yaml`, `check-readme.yaml`, `actionlint.yaml`)
  are unchanged and should continue to pass.

## Finding counts

| Rule | Found | Fixed | Manual review |
|------|-------|-------|---------------|
| template-injection | 5 | 3 (this patch) + 2 (upstream #88) | 0 |
| github-env | 1 | 0 | 1 |
| anonymous-definition | 5 | 0 | 0 (suppressed in zizmor.yml) |
| concurrency-limits | 4 | 0 | 0 (suppressed in zizmor.yml) |

Refs: PSEC-923