### PR TITLE
fix(ci): resolve shellcheck findings in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ runs:
         # Extract directly to destination and add to PATH
         mkdir -p "${HOME}/.local/bin"
         tar -xzf "${crane_tar}" -C "${HOME}/.local/bin" crane
-        echo "${HOME}/.local/bin" >> $GITHUB_PATH
+        echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
 
         # Verify installation
         crane version
@@ -194,7 +194,7 @@ runs:
               proxy="${mapping%%=*}"
               upstream="${mapping#*=}"
               if [[ "$lookup_image" == "${proxy}"* ]]; then
-                lookup_image="${upstream}${lookup_image#${proxy}}"
+                lookup_image="${upstream}${lookup_image#"${proxy}"}"
                 echo "  Registry mapping: querying $lookup_image instead of $image"
                 break
               fi
@@ -218,8 +218,9 @@ runs:
               echo "Digest $digest for image $image is different, new digest is $updated_digest, updating..."
               sed -i -e "s|$image@$digest|$image@$updated_digest|g" "$file"
               # Add file to changed_files array if not already present
-              # shellcheck disable=SC2076 -- quoted RHS is intentional: literal match guards
-              #   against regex metacharacters in filenames; see docs/backlog.md for refactor note
+              # Quoted RHS is intentional: literal match guards against regex
+              # metacharacters in filenames; see docs/backlog.md for refactor note
+              # shellcheck disable=SC2076
               if [[ ! " ${changed_files[*]} " =~ " ${file} " ]]; then
                 changed_files+=("$file")
               fi
@@ -234,7 +235,7 @@ runs:
         done < <(
             find_args=()
             for i in "${!PATTERNS[@]}"; do
-                if [ $i -eq 0 ]; then
+                if [ "$i" -eq 0 ]; then
                     find_args+=(-name "${PATTERNS[$i]}")
                 else
                     find_args+=(-o -name "${PATTERNS[$i]}")
@@ -261,9 +262,9 @@ runs:
       shell: bash
       run: |
         git diff --stat
-        echo "create_pr_update=false" >> $GITHUB_OUTPUT
+        echo "create_pr_update=false" >> "$GITHUB_OUTPUT"
         if [[ $(git diff --stat) != '' ]] && [[ "${CREATE_PR}" == 'true' ]]; then
-          echo "create_pr_update=true" >> $GITHUB_OUTPUT
+          echo "create_pr_update=true" >> "$GITHUB_OUTPUT"
           echo "diff<<EOF" >> "${GITHUB_OUTPUT}"
           git diff >> "${GITHUB_OUTPUT}"
           echo "EOF" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION

## Summary

Follow-up to #90: resolve shellcheck findings in `action.yml` that were missed
because our script ran at `--severity=warning` (matching below the `info` level
where SC2086 fires), and fix a shellcheck directive comment format bug introduced
in #90 (the `-- reason` inline annotation syntax is not supported in shellcheck
0.9.0 and causes SC1072/SC1073 parse errors).

Part of the PSEC-923 GitHub Actions security remediation campaign.

## Patch 1: fix(ci): resolve shellcheck findings in action.yml

**File changed**: `action.yml`

Five fixes:

1. **Quote `$GITHUB_PATH` redirect** (SC2086, Install crane step):
   `>> $GITHUB_PATH` → `>> "$GITHUB_PATH"`

2. **Quote inner expansion in parameter substitution** (SC2295, step 2):
   `${lookup_image#${proxy}}` → `${lookup_image#"${proxy}"}` — unquoted inner
   expansions inside `${var#pattern}` are matched as glob patterns, not literals.

3. **Fix SC2076 disable comment format** (step 2):
   The `# shellcheck disable=SC2076 -- reason` syntax is not supported in
   shellcheck 0.9.0; `--` is parsed as a new directive key, causing SC1072/SC1073
   errors. Move the explanation to a preceding comment line.

4. **Quote loop index in `[ ]` test** (SC2086, step 2):
   `if [ $i -eq 0 ]` → `if [ "$i" -eq 0 ]`

5. **Quote `$GITHUB_OUTPUT` redirects** (SC2086, Check workspace step, x2):
   `>> $GITHUB_OUTPUT` → `>> "$GITHUB_OUTPUT"` (both occurrences)

## Testing

- The updated zizmor workflow (with `persona: pedantic` and `.github/zizmor.yml`
  suppressions from #90) will self-validate on this PR.
- Confirm the "Run zizmor" step passes with zero findings.
- The existing test workflows (`test.yaml`, `check-readme.yaml`, `actionlint.yaml`)
  are unchanged and should continue to pass.

Refs: PSEC-923