### PR TITLE
Run the check-workspace git diff in working-dir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -260,6 +260,7 @@ runs:
       env:
         CREATE_PR: ${{ inputs.create-pr }}
       shell: bash
+      working-directory: ${{ inputs.working-dir }}
       run: |
         git diff --stat
         echo "create_pr_update=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes #49

## Problem

digestabot is a composite action whose steps are supposed to operate in the directory given by the `working-dir` input. The `update_files` step honors it (it runs `find "${INPUTS_WORKING_DIR}" ...`), but the `Check workspace` step runs `git diff` from the repository root and ignores `working-dir`.

That is fine when `working-dir` is a subdirectory of the same checked-out repository, which is why the existing `test-working-dir` job passes. It breaks when the action is pointed at a checkout placed in its own subdirectory of `$GITHUB_WORKSPACE`, for example a monorepo cloned into `$GITHUB_WORKSPACE/my_repo`. In that case the repository root is not a git working tree, so `git diff --stat` fails:

```
Run git diff --stat
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
usage: git diff --no-index [<options>] <path> <path>
```

and the action errors out before it can open the update PR.

## Fix

Add `working-directory: ${{ inputs.working-dir }}` to the `Check workspace` step so its `git diff` runs in the same tree the other steps already use. The step invokes `git diff` three times (the `--stat` check and the diff captured into `GITHUB_OUTPUT` for the Create Pull Request step), so setting `working-directory` once on the step is the smallest change that covers all of them.

`working-dir` defaults to `.`, so `working-directory: .` is a no-op for the normal single-repo setup and existing behavior is unchanged.

```diff
     - name: Check workspace
       id: create_pr_update
       env:
         CREATE_PR: ${{ inputs.create-pr }}
       shell: bash
+      working-directory: ${{ inputs.working-dir }}
       run: |
         git diff --stat
```

## Verification

- `action.yml` still parses as valid YAML.
- The existing `test-working-dir` and `test-registry-map` jobs continue to pass (both check out at the repo root, so the diff tree is unchanged for them).

## Note (out of scope here)

The issue also mentions the Create Pull Request step. That step now uses `actions/github-script` and shells out to git from the workspace; if a separate-checkout monorepo scenario needs full support there too, the git invocations inside that script would need to `cd` into `working-dir` (the `WORKING_DIR` env var is already passed to the step). I kept this PR to the one-line diff fix for the reported `git diff` error so it is easy to review; happy to follow up on the PR-creation path in a separate change if you would like.
